### PR TITLE
Check for else statement in compiled output

### DIFF
--- a/src/Compile.rsc
+++ b/src/Compile.rsc
@@ -243,12 +243,18 @@ str refreshVisibility(AForm f, TEnv tenv, RefGraph rg) {
   for (m <- condMap) {
     ret += "if(<expr2js(m.expr, tenv, rg)>){";
       ret += "document.getElementById(\"ifStatement<m.conditionalId>\").style.display = \"block\";";
-      ret += "document.getElementById(\"elseStatement<m.conditionalId>\").style.display = \"none\";";
+      ret += "let tmp = document.getElementById(\"elseStatement<m.conditionalId>\");";
+      ret += "if(tmp){";
+        ret += "tmp.style.display = \"none\";";
+      ret += "}";
     ret += "}";
     ret += "else{";
       ret += "document.getElementById(\"ifStatement<m.conditionalId>\").style.display = \"none\";";
-      ret += "document.getElementById(\"elseStatement<m.conditionalId>\").style.display = \"block\";";
-    ret += "};";
+      ret += "let tmp = document.getElementById(\"elseStatement<m.conditionalId>\");";
+      ret += "if(tmp){";
+        ret += "tmp.style.display = \"block\";";
+      ret += "}";
+    ret += "}";
   }
   return ret;
 }


### PR DESCRIPTION
Attempting to change the visibility of the else part of the statement when it does not exist results in a TypeError.